### PR TITLE
Handle selection toggle properly

### DIFF
--- a/src/data-table/data-cell.jsx
+++ b/src/data-table/data-cell.jsx
@@ -17,10 +17,10 @@ class DataCell extends React.PureComponent {
       return;
     }
 
-    qlik.backendApi.selectValues(0, [measurement.parents.dimension1.elementNumber], true);
+    qlik.backendApi.selectValues(0, [measurement.parents.dimension1.elementNumber], false);
 
     if (hasSecondDimension) {
-      qlik.backendApi.selectValues(1, [measurement.parents.dimension2.elementNumber], true);
+      qlik.backendApi.selectValues(1, [measurement.parents.dimension2.elementNumber], false);
     }
   }
 


### PR DESCRIPTION
-Previously, the cell selection would toggle
 the current selection. This meant, if a column
 is already selected when making a cell selection,
 the column selection would toggle off. With this
 fix the column selection stays on.

Issue: DEB-233