### PR TITLE
fix: disable data export as per QMC

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,19 +115,21 @@ export default {
       return menu;
     }
 
-    menu.addItem({
-      translation: 'Export as XLS',
-      tid: 'export-excel',
-      icon: 'export',
-      select: () => {
-        exportXLS(
-          this.$element,
-          this.$scope.layout.title,
-          this.$scope.layout.subtitle,
-          this.$scope.layout.footnote
-        );
-      }
-    });
+    if (typeof (this.backendApi.model.layout.qMeta.privileges[3]) !== 'undefined' && this.backendApi.model.layout.qMeta.privileges[3] === 'exportdata') {
+      menu.addItem({
+        translation: 'Export as XLS',
+        tid: 'export-excel',
+        icon: 'export',
+        select: () => {
+          exportXLS(
+            this.$element,
+            this.$scope.layout.title,
+            this.$scope.layout.subtitle,
+            this.$scope.layout.footnote
+          );
+        }
+      });
+    }
     return menu;
   },
   version: 1.0


### PR DESCRIPTION
Disable data export option on UI when "ExportAppData" security rule is disabled in QMC