### PR TITLE
pivot selection refresh fixed

### DIFF
--- a/src/data-table/index.jsx
+++ b/src/data-table/index.jsx
@@ -121,7 +121,7 @@ class DataTable extends React.PureComponent {
               };
 
               return (
-                <tr key={dimensionEntry.displayValue}>
+                <tr key={`${dimensionEntry.displayValue}-${dimensionIndex}-separator`}>
                   {!renderData ?
                     <RowHeader
                       component={component}

--- a/src/headers-table/index.jsx
+++ b/src/headers-table/index.jsx
@@ -77,7 +77,7 @@ class HeadersTable extends React.PureComponent {
                     colSpan={measurements.length}
                     component={component}
                     entry={entry}
-                    key={entry.displayValue}
+                    key={`${entry.displayValue}-${index}-separator`}
                     styling={styling}
                   />
                 );


### PR DESCRIPTION
This bug is regarding bug QB-1147, P&L pivot not refreshing properly after selection.
Files changed are,
src/data-table/index.jsx,
src/headers-table/index.jsx

