### PR TITLE
fix: correctly check data export privileges

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,7 @@ export default {
       return menu;
     }
 
-    if (typeof (this.backendApi.model.layout.qMeta.privileges[3]) !== 'undefined' && this.backendApi.model.layout.qMeta.privileges[3] === 'exportdata') {
+    if (this.backendApi.model.layout.qMeta.privileges.indexOf('exportdata') !== -1) {
       menu.addItem({
         translation: 'Export as XLS',
         tid: 'export-excel',


### PR DESCRIPTION
Previous fix of export (QB-262) checked for privileges[3] which is incorrect as the privileges array is not of a static size.
New fix instead checks the existence of 'exportData' in the array.