### PR TITLE
fix: enable Export as XLS option on qcs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,10 @@ export default {
     return snapshotLayout;
   },
   getContextMenu (obj, menu) {
+    if (!this.$scope.layout.allowexportxls) {
+      return menu;
+    }
+
     if (this.backendApi.model.layout.qMeta.privileges.indexOf('exportdata') !== -1) {
       menu.addItem({
         translation: 'Export as XLS',

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import definition from "./definition";
 import { exportXLS } from "./excel-export";
 import { initializeDataCube, initializeDesignList } from "./dataset";
 import initializeStore from "./store";
-import qlik from "qlik";
 import React from "react";
 import ReactDOM from "react-dom";
 import Root from "./root.jsx";
@@ -105,18 +104,7 @@ export default {
     );
     return snapshotLayout;
   },
-  async getContextMenu (obj, menu) {
-    const app = qlik.currApp(this);
-    const isPersonalResult = await app.global.isPersonalMode();
-    // This check is done because the desktop wrapper blocks downloads.
-    // It also blocks this feature in QCS currently as isPersonalMode returns true
-    if (
-      !this.$scope.layout.allowexportxls ||
-      (isPersonalResult && isPersonalResult.qReturn)
-    ) {
-      return menu;
-    }
-
+  getContextMenu (obj, menu) {
     if (this.backendApi.model.layout.qMeta.privileges.indexOf('exportdata') !== -1) {
       menu.addItem({
         translation: 'Export as XLS',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,10 @@ const packageJSON = require('./package.json');
 const path = require('path');
 
 const DIST = path.resolve("./dist");
+// eslint-disable-next-line no-process-env
 const MODE = process.env.NODE_ENV || 'development';
-const SOURCE_MAP = 'sourec-map';
-const DEVTOOL = (process.env.NODE_ENV === 'development') ? SOURCE_MAP : false;
+const SOURCE_MAP = 'source-map';
+const DEVTOOL = MODE === 'development' ? SOURCE_MAP : false;
 
 console.log('Webpack mode:', MODE); // eslint-disable-line no-console
 


### PR DESCRIPTION
Jira bug: https://jira.qlikdev.com/browse/QB-5202

The fix will be enable Export as XLS option in the context menu on QCS, but will also enable that option on desktop version which will causing issues on desktop version. Please take a look in the Jira bug for more information.

Need to test on desktop how it reacts when clicking on Export as XLS. (@Caele said will be having no reaction when clicking on it on desktop).
Need to add doc to state the behaviour on build in browser.