### PR TITLE
fix: Export as XLS in QCS

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,8 @@ gulp.task('qext', function () {
 		repository: pkg.repository,
 		dependencies: {
 			'qlik-sense': '>=5.5.x'
-		}
+		},
+		__next: true
 	};
 	if (pkg.contributors) {
 		qext.contributors = pkg.contributors;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import definition from "./definition";
 import { exportXLS } from "./excel-export";
 import { initializeDataCube, initializeDesignList } from "./dataset";
 import initializeStore from "./store";
+import qlik from "qlik";
 import React from "react";
 import ReactDOM from "react-dom";
 import Root from "./root.jsx";
@@ -12,7 +13,7 @@ if (!window._babelPolyfill) {
   require("@babel/polyfill"); // eslint-disable-line global-require
 }
 
-export default {
+export default ({ flags }) => ({
   design: {
     dimensions: {
       max: 1,
@@ -104,12 +105,18 @@ export default {
     );
     return snapshotLayout;
   },
-  getContextMenu (obj, menu) {
+  async getContextMenu (obj, menu) {
     if (!this.$scope.layout.allowexportxls) {
       return menu;
     }
 
-    if (this.backendApi.model.layout.qMeta.privileges.indexOf('exportdata') !== -1) {
+    // Export as XLS is removed from desktop because the desktop wrapper blocks downloads.
+    // isPersonalMode returns true for both desktop and QCS
+    // By checking both if has download dialog and if is QCS can enable Export as XLS option on QCS
+    const app = qlik.currApp(this);
+    const isPersonalResult = await app.global.isPersonalMode();
+
+    if (this.backendApi.model.layout.qMeta.privileges.indexOf('exportdata') !== -1 || (flags.isEnabled('DOWNLOAD_USE_REPORTING') && isPersonalResult && isPersonalResult.qReturn)) {
       menu.addItem({
         translation: 'Export as XLS',
         tid: 'export-excel',
@@ -127,4 +134,4 @@ export default {
     return menu;
   },
   version: 1.0
-};
+});

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import definition from "./definition";
 import { exportXLS } from "./excel-export";
 import { initializeDataCube, initializeDesignList } from "./dataset";
 import initializeStore from "./store";
-import qlik from "qlik";
 import React from "react";
 import ReactDOM from "react-dom";
 import Root from "./root.jsx";
@@ -110,13 +109,17 @@ export default ({ flags }) => ({
       return menu;
     }
 
-    // Export as XLS is removed from desktop because the desktop wrapper blocks downloads.
-    // isPersonalMode returns true for both desktop and QCS
-    // By checking both if has download dialog and if is QCS can enable Export as XLS option on QCS
-    const app = qlik.currApp(this);
+    const app = this.backendApi.model.app;
     const isPersonalResult = await app.global.isPersonalMode();
 
-    if (this.backendApi.model.layout.qMeta.privileges.indexOf('exportdata') !== -1 || (flags.isEnabled('DOWNLOAD_USE_REPORTING') && isPersonalResult && isPersonalResult.qReturn)) {
+    // Export as XLS option is removed from desktop because the desktop wrapper blocks downloads.
+    // Enabled for windows and QCS
+    // isPersonalMode returns true for both desktop and QCS
+    // By checking both if has download dialog and if is QCS can enable Export as XLS option on QCS
+    if (
+      (this.backendApi.model.layout.qMeta.privileges.includes('exportdata') && !isPersonalResult) ||
+      (flags.isEnabled('DOWNLOAD_USE_REPORTING') && isPersonalResult)
+    ) {
       menu.addItem({
         translation: 'Export as XLS',
         tid: 'export-excel',


### PR DESCRIPTION
In QCS, there is no setting for exportdata in privileges. Have to use both download dialog and isPersonalMode to determine if it is QCS and add Export as XLS option.